### PR TITLE
fix: normalize bug, when input undefined, or basic type with a model

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28,6 +28,8 @@ function isPlainObject(obj) {
   return Object.getPrototypeOf(obj) === proto;
 }
 
+const ANONYMOUS_MODEL = 'AnonymousModel';
+
 const normalize = (input, model) => {
   return Array.isArray(input) ? normalizeFromArray(input, model) : normalizeFromObject(input, model);
 };
@@ -89,6 +91,14 @@ const normalizeFromType = (entities, visitedEntities) => {
 };
 
 function normalizeFromModel(input, model) {
+  if (!input) {
+    return;
+  }
+
+  if (!isObject(input)) {
+    return input;
+  }
+
   if (this.visitedEntities.some(entity => entity === input)) {
     return getIdentifierValue(input, model);
   } else {
@@ -145,6 +155,10 @@ function normalizeFromAnyType(input, type) {
   if (isLateType(type)) {
     return this.normalizeFromLateType(input, type);
   } else if (isModelType(type)) {
+    if (type.name === ANONYMOUS_MODEL) {
+      return input;
+    }
+
     return this.normalizeFromModel(input, type);
   } else if (isUnionType(type)) {
     return this.normalizeFromUnionType(input, type);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-state-tree-normalizr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A tool for normalize data from mobx-state-tree types.model",
   "repository": "https://github.com/space-fe/mobx-state-tree-normalizr",
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import { isModelType, isReferenceType, isLateType, isUnionType, isOptionalType, isArrayType } from 'mobx-state-tree'
 import { isObject, isPlainObject } from './utils/index.js'
 
+const ANONYMOUS_MODEL = 'AnonymousModel'
+
 const normalize = (input, model) => {
   return Array.isArray(input) ? normalizeFromArray(input, model) : normalizeFromObject(input, model)
 }
@@ -55,6 +57,14 @@ const normalizeFromType = (entities, visitedEntities) => {
 }
 
 function normalizeFromModel(input, model) {
+  if (!input) {
+    return
+  }
+
+  if (!isObject(input)) {
+    return input
+  }
+
   if (this.visitedEntities.some(entity => entity === input)) {
     return getIdentifierValue(input, model)
   } else {
@@ -112,6 +122,10 @@ function normalizeFromAnyType(input, type) {
   if (isLateType(type)) {
     return this.normalizeFromLateType(input, type)
   } else if (isModelType(type)) {
+    if (type.name === ANONYMOUS_MODEL) {
+      return input
+    }
+
     return this.normalizeFromModel(input, type)
   } else if (isUnionType(type)) {
     return this.normalizeFromUnionType(input, type)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -125,6 +125,70 @@ describe('normalize', () => {
     })
   })
 
+  test('no need to normalize when a model without name property', () => {
+    const User = types.model({
+      id: types.string,
+      name: types.string
+    })
+
+    const Article = types.model('article', {
+      id: types.string,
+      author: User
+    })
+
+    const input = {
+      id: '123',
+      author: {
+        id: '8472',
+        name: 'Paul'
+      }
+    }
+
+    expect(normalize(input, Article)).toEqual({
+      result: '123',
+      entities: {
+        article: {
+          '123': {
+            id: '123',
+            author: {
+              id: '8472',
+              name: 'Paul'
+            }
+          }
+        }
+      }
+    })
+  })
+
+  test('when the data type of input is basic type and normalize with a named model, just return the value of input', () => {
+    const User = types.model('User', {
+      id: types.string,
+      name: types.string
+    })
+
+    const Article = types.model('article', {
+      id: types.string,
+      author: User
+    })
+
+    const input = {
+      id: '123',
+      author: 'user/1'
+    }
+
+    expect(normalize(input, Article)).toEqual({
+      result: '123',
+      entities: {
+        article: {
+          '123': {
+            id: '123',
+            author: 'user/1'
+          }
+        }
+      }
+    })
+  })
+
   test('can normalize nested entity', () => {
     const User = types.model('user', {
       id: types.string,
@@ -143,6 +207,7 @@ describe('normalize', () => {
         name: 'Paul'
       }
     }
+
     expect(normalize(input, Article)).toEqual({
       result: '123',
       entities: {


### PR DESCRIPTION
1. fix when input is undefined/null/...
2. fix when input is basic data type and normalize with a named model
3. no need to normalize when the model without a name.